### PR TITLE
[php][tutorial] removed white space

### DIFF
--- a/php/tutorial.php
+++ b/php/tutorial.php
@@ -183,10 +183,7 @@ $body_json = json_encode($body);
 
 print_line("\n********Write to the share - using JSON********");
 $api_url = "http://api.linkedin.com/v1/people/~/shares";
-$oauth->fetch($api_url, $body_json, OAUTH_HTTP_METHOD_POST, array(
-																"Content-Type" => "application/json",
-																"x-li-format" => "json"
-															  ));
+$oauth->fetch($api_url, $body_json, OAUTH_HTTP_METHOD_POST, array("Content-Type" => "application/json",	"x-li-format" => "json"));
 print_response($oauth);
 
 // Note that the same query param used to post to twitter for XML also applies to JSON


### PR DESCRIPTION
At first look, it looks llike there is a bug. But there is white space.
https://github.com/linkedin/api-get-started/blob/master/php/tutorial.php#L186
